### PR TITLE
WIP - Python3 migration

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -4,7 +4,7 @@
        name="C More"
        provider-name="emilsvennesson">
   <requires>
-    <import addon="xbmc.python" version="2.25.0"/>
+    <import addon="xbmc.python" version="3.0.0"/>
     <import addon="script.module.inputstreamhelper" version="0.2.4"/>
     <import addon="script.module.requests" version="2.9.1"/>
     <import addon="script.module.routing" version="0.2.0" />

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -74,7 +74,7 @@ def list_channels():
             'fanart': helper.c.image_proxy('https://img-cdn-cmore.b17g.services/{image_id}/cmore475.img'.format(image_id=current_program['imageId']))
         }
 
-        list_title = '[B]{0}[/B]: {1}'.format(channel['title'].encode('utf-8'), coloring(current_program['title'].encode('utf-8'), 'live'))
+        list_title = '[B]{0}[/B]: {1}'.format(channel['title'], coloring(current_program['title'], 'live'))
         helper.add_item(list_title, plugin.url_for(play, video_id=channel['asset']['id']), playable=True, info=info, art=art)
     helper.eod()
 
@@ -224,8 +224,8 @@ def add_sport(asset):
         'cast': [x['name'] for x in asset['credits']]
     }
 
-    list_title = '[B]{0}:[/B] {1}'.format(coloring(start_time, event_status).encode('utf-8'),
-                                          info['title'].encode('utf-8'))
+    list_title = '[B]{0}:[/B] {1}'.format(coloring(start_time, event_status),
+                                          info['title'])
     helper.add_item(list_title, plugin_url, info=info, art=add_art(asset), content='episodes', playable=playable)
 
 
@@ -266,7 +266,7 @@ def episode_list_title(asset):
 
     return '[B]S{season_format}E{episode_format}[/B]: {title}'.format(season_format=season_format,
                                                                       episode_format=episode_format,
-                                                                      title=title.encode('utf-8'))
+                                                                      title=title)
 
 
 def add_art(asset):

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -128,7 +128,7 @@ def list_assets(params=[]):
         if asset['type'] in assets_routing:
             assets_routing[asset['type']](asset)
         else:
-            helper.log('Unsupported asset found: %s' % asset['type'])
+            helper.log('Unsupported asset found: {a}'.format(a=asset['type']))
     helper.eod()
 
 
@@ -316,7 +316,7 @@ def coloring(text, meaning):
     elif meaning == 'upcoming':
         color = 'FFF16C00'
 
-    colored_text = '[COLOR=%s]%s[/COLOR]' % (color, text)
+    colored_text = '[COLOR={c}]{t}[/COLOR]'.format(c=color, t=text)
     return colored_text
 
 

--- a/resources/lib/cmore.py
+++ b/resources/lib/cmore.py
@@ -13,6 +13,14 @@ from datetime import datetime, timedelta
 import requests
 import iso8601
 
+# Handle to-text conversion for both Python 2 and 3
+try:
+    # Python 2 built-in
+    unicode
+except NameError:
+    # Use str in Python 3
+    unicode = str
+
 
 class CMore(object):
     base_url = 'https://cmore-mobile-bff.b17g.services'

--- a/resources/lib/cmore.py
+++ b/resources/lib/cmore.py
@@ -41,25 +41,25 @@ class CMore(object):
         """C More class log method."""
         if self.debug:
             try:
-                print('[C More]: %s') % string
+                print('[C More]: {s}'.format(s=string))
             except UnicodeEncodeError:
                 # we can't anticipate everything in unicode they might throw at
                 # us, but we can handle a simple BOM
                 bom = unicode(codecs.BOM_UTF8, 'utf8')
-                print('[C More]: %s' % string.replace(bom, ''))
+                print('[C More]: {s}'.format(s=string.replace(bom, '')))
             except:
                 pass
 
     def make_request(self, url, method, params=None, payload=None, headers=None):
         """Make an HTTP request. Return the response."""
-        self.log('Request URL: %s' % url)
-        self.log('Method: %s' % method)
+        self.log('Request URL: {u}'.format(u=url))
+        self.log('Method: {m}'.format(m=method))
         if params:
-            self.log('Params: %s' % params)
+            self.log('Params: {p}'.format(p=params))
         if payload:
-            self.log('Payload: %s' % payload)
+            self.log('Payload: {p}'.format(p=payload))
         if headers:
-            self.log('Headers: %s' % headers)
+            self.log('Headers: {h}'.format(h=headers))
 
         if method == 'get':
             req = self.http_session.get(url, params=params, headers=headers)
@@ -67,8 +67,8 @@ class CMore(object):
             req = self.http_session.put(url, params=params, data=payload, headers=headers)
         else:  # post
             req = self.http_session.post(url, params=params, data=payload, headers=headers)
-        self.log('Response code: %s' % req.status_code)
-        self.log('Response: %s' % req.content)
+        self.log('Response code: {s}'.format(s=req.status_code))
+        self.log('Response: {c}'.format(c=req.content))
 
         return self.parse_response(req.content)
 

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -1,6 +1,6 @@
 import re
 
-from cmore import CMore
+from .cmore import CMore
 
 import xbmc
 import xbmcvfs

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -1,5 +1,3 @@
-import os
-import urllib
 import re
 
 from cmore import CMore

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -50,7 +50,7 @@ class KodiHelper(object):
 
     def log(self, string):
         msg = '{p}: {s}'.format(p=self.logging_prefix, s=string)
-        xbmc.log(msg=msg.encode('utf-8'), level=xbmc.LOGDEBUG)
+        xbmc.log(msg=msg, level=xbmc.LOGDEBUG)
 
     def dialog(self, dialog_type, heading, message=None, options=None, nolabel=None, yeslabel=None):
         dialog = xbmcgui.Dialog()

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -69,7 +69,8 @@ class KodiHelper(object):
         keyboard = xbmc.Keyboard('', heading, hidden)
         keyboard.doModal()
         if keyboard.isConfirmed():
-            query = keyboard.getText().decode('utf-8')
+            # FIXME: Not compatible with Python 2.X!
+            query = keyboard.getText()
             self.log('User input string: {q}'.format(query))
         else:
             query = None

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -233,7 +233,7 @@ class KodiHelper(object):
         ia_helper = inputstreamhelper.Helper(protocol, drm=drm)
         if ia_helper.check_inputstream():
             playitem = xbmcgui.ListItem(path=stream['manifestUrl'])
-            playitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
+            playitem.setProperty('inputstream', 'inputstream.adaptive')
             playitem.setProperty('inputstream.adaptive.manifest_type',
                                  protocol)
             if drm:

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -233,10 +233,19 @@ class KodiHelper(object):
         if ia_helper.check_inputstream():
             playitem = xbmcgui.ListItem(path=stream['manifestUrl'])
             playitem.setProperty('inputstreamaddon', 'inputstream.adaptive')
-            playitem.setProperty('inputstream.adaptive.manifest_type', protocol)
+            playitem.setProperty('inputstream.adaptive.manifest_type',
+                                 protocol)
             if drm:
-                playitem.setProperty('inputstream.adaptive.license_type', 'com.widevine.alpha')
-                playitem.setProperty('inputstream.adaptive.license_key', stream['license']['castlabsServer'] + '|Content-Type=&x-dt-auth-token=%s|R{SSM}|' % stream['license']['castlabsToken'])
+                playitem.setProperty('inputstream.adaptive.license_type',
+                                     'com.widevine.alpha')
+                license_server = stream['license']['castlabsServer']
+                license_header = '&'.join(['Content-Type=',
+                                           'x-dt-auth-token=' +
+                                           stream['license']['castlabsToken']])
+                license_key = '{s}|{h}|{data}|'.format(s=license_server,
+                                                       h=license_header,
+                                                       data='R{SSM}')
+                playitem.setProperty('inputstream.adaptive.license_key', license_key)
             xbmcplugin.setResolvedUrl(self.handle, True, listitem=playitem)
 
     def get_as_bool(self, string):

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -71,7 +71,7 @@ class KodiHelper(object):
         if keyboard.isConfirmed():
             # FIXME: Not compatible with Python 2.X!
             query = keyboard.getText()
-            self.log('User input string: {q}'.format(query))
+            self.log('User input string: {q}'.format(q=query))
         else:
             query = None
 

--- a/resources/lib/kodihelper.py
+++ b/resources/lib/kodihelper.py
@@ -22,7 +22,8 @@ class KodiHelper(object):
         self.addon_name = addon.getAddonInfo('id')
         self.addon_version = addon.getAddonInfo('version')
         self.language = addon.getLocalizedString
-        self.logging_prefix = '[%s-%s]' % (self.addon_name, self.addon_version)
+        self.logging_prefix = '[{n}-{v}]'.format(n=self.addon_name,
+                                                 v=self.addon_version)
         if not xbmcvfs.exists(self.addon_profile):
             xbmcvfs.mkdir(self.addon_profile)
         self.c = CMore(self.addon_profile, self.get_setting('locale'), True)
@@ -50,7 +51,7 @@ class KodiHelper(object):
         ia_addon.openSettings()
 
     def log(self, string):
-        msg = '%s: %s' % (self.logging_prefix, string)
+        msg = '{p}: {s}'.format(p=self.logging_prefix, s=string)
         xbmc.log(msg=msg.encode('utf-8'), level=xbmc.LOGDEBUG)
 
     def dialog(self, dialog_type, heading, message=None, options=None, nolabel=None, yeslabel=None):
@@ -71,7 +72,7 @@ class KodiHelper(object):
         keyboard.doModal()
         if keyboard.isConfirmed():
             query = keyboard.getText().decode('utf-8')
-            self.log('User input string: %s' % query)
+            self.log('User input string: {q}'.format(query))
         else:
             query = None
 

--- a/service.py
+++ b/service.py
@@ -8,7 +8,6 @@ import SocketServer
 import socket
 from xbmc import Monitor
 from resources.lib.kodihelper import KodiHelper
-from resources.lib.WidevineHTTPRequestHandler import WidevineHTTPRequestHandler
 
 # helper function to select an unused port on the host machine
 def select_unused_port():


### PR DESCRIPTION
This pull request contains what I think is necessary in order to make this plugin Python 3 compatible, while still retaining compatibility with Python 2 so installs on older Kodi versions don't break. The changes are largely based on suggestions by the 2to3 script, but the are a couple of things I've ignored as I don't think they're necessary. There are also some changes that are of the recommended sort and not strictly necessary for Python 3 compatibility (replacement of printf style formatting come to mind).

As I currently don't have a Widevine capable device that is also running Kodi 19 my changes are not tested in a Python 3 environment, but rather a Python 2 one (where it works fine as far as I can tell). As such I wouldn't merge this PR until at least some basic verification has been carried out on Kodi 19. For that reason I'm also marking it a work in progress.